### PR TITLE
Add query_bulk to GrpcClient class with Feather support

### DIFF
--- a/chalk_ruby.gemspec
+++ b/chalk_ruby.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'
-  spec.add_dependency 'red-arrow', '~> 12.0.0'
+  spec.add_dependency 'red-arrow', '~> 18.0.0'
 
   spec.add_development_dependency 'httpclient'
   spec.add_development_dependency 'm'

--- a/chalk_ruby.gemspec
+++ b/chalk_ruby.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'
+  spec.add_dependency 'red-arrow', '~> 12.0.0'
 
   spec.add_development_dependency 'httpclient'
   spec.add_development_dependency 'm'

--- a/lib/chalk_ruby/grpc/auth_interceptor.rb
+++ b/lib/chalk_ruby/grpc/auth_interceptor.rb
@@ -11,12 +11,13 @@ module ChalkRuby
         @client_secret = client_secret
         @environment_id = environment_id
         @token = nil
+        @token_expiry = nil
       end
 
       def request_response(request:, call:, method:, metadata:)
-        # If we haven't fetched a token yet or if you'd like to handle token expiration,
-        # this is where you'd refresh it. For now, let's assume a long-lived token.
-        if @token.nil?
+
+        # Leave 1 minute buffer before refreshing auth token
+        if @token.nil? || @token_expiry.nil? || Time.now >= (@token_expiry - 60)
           response = @auth_stub.get_token(
             Chalk::Server::V1::GetTokenRequest.new(
               client_id: @client_id,
@@ -24,6 +25,9 @@ module ChalkRuby
             )
           )
           @token = response.access_token
+
+          # expires_in assumes to be 'seconds'
+          @token_expiry = Time.now + response.expires_in
         end
 
 

--- a/lib/chalk_ruby/grpc_client.rb
+++ b/lib/chalk_ruby/grpc_client.rb
@@ -159,6 +159,7 @@ module ChalkRuby
       # Convert input to feather format
       inputs_feather = to_feather(input)
 
+
       r = Chalk::Common::V1::OnlineQueryBulkRequest.new(
         inputs_feather: inputs_feather,
         outputs: output.map { |o| Chalk::Common::V1::OutputExpr.new(feature_fqn: o) },
@@ -386,7 +387,7 @@ module ChalkRuby
       array_input_hash = input_hash.transform_values { |v| v.is_a?(Array) ? v : [v] }
 
       # Create a table from the transformed input hash
-      table = Arrow::Table.new(array_input_hash).
+      table = Arrow::Table.new(array_input_hash)
 
       # Write to feather format in memory
       buffer = Arrow::ResizableBuffer.new(0)
@@ -395,7 +396,8 @@ module ChalkRuby
 
       table.write_as_feather(output)
 
-      buffer.data.to_s.b
+      # Remove trailing null bytes from the resizable buffer; the buffer is 512 aligned
+      buffer.data.to_s.b.gsub(/ARROW1(.*)ARROW1.*/m) {"ARROW1#{$1}ARROW1"}
     end
     end
   end

--- a/lib/chalk_ruby/grpc_client.rb
+++ b/lib/chalk_ruby/grpc_client.rb
@@ -379,19 +379,23 @@ module ChalkRuby
 
       private
 
-      def to_feather(input_hash)
-        require 'arrow'
+    def to_feather(input_hash)
+      require 'arrow'
 
-        # Create a table from the input hash
-        table = Arrow::Table.new(input_hash)
-        
-        # Write to feather format in memory
-        buffer = Arrow::Buffer.new
-        Arrow::FeatherFileWriter.open(buffer) do |writer|
-          writer.write(table)
-        end
-        
-        buffer.data.to_s
-      end
+      # Ensure all values in the input hash are arrays
+      array_input_hash = input_hash.transform_values { |v| v.is_a?(Array) ? v : [v] }
+
+      # Create a table from the transformed input hash
+      table = Arrow::Table.new(array_input_hash).
+
+      # Write to feather format in memory
+      buffer = Arrow::ResizableBuffer.new(0)
+
+      output = Arrow::BufferOutputStream.new(buffer)
+
+      table.write_as_feather(output)
+
+      buffer.data.to_s.b
+    end
     end
   end

--- a/test/chalk_ruby/integration/grpc_client_test.rb
+++ b/test/chalk_ruby/integration/grpc_client_test.rb
@@ -1,0 +1,27 @@
+require 'rspec'
+require 'chalk_ruby'
+
+RSpec.describe ChalkRuby::GrpcClient do
+  describe '#query_bulk' do
+    let(:client) do
+      ChalkRuby::GrpcClient.create(
+        ENV.fetch('CHALK_CLIENT_ID'),
+        ENV.fetch('CHALK_CLIENT_SECRET'),
+        ENV.fetch('CHALK_ENVIRONMENT', 'tmnmc9beyujew'),
+        ENV.fetch('CHALK_QUERY_SERVER', 'standard-gke.chalk-develop.gcp.chalk.ai'),
+        ENV.fetch('CHALK_API_SERVER', 'api.staging.chalk.ai:443')
+      )
+    end
+
+    it 'can perform bulk queries' do
+      response = client.query_bulk(
+        input: { 'user.id': 1 },
+        output: %w(user.id user.socure_score)
+      )
+
+      expect(response).not_to be_nil
+      # The response should be a OnlineQueryBulkResponse
+      expect(response).to be_a(Chalk::Common::V1::OnlineQueryBulkResponse)
+    end
+  end
+end


### PR DESCRIPTION
Added a new `query_bulk` method to the `GrpcClient` class to utilize the `OnlineQueryBulk` proto method. Implemented Feather format conversion using the `red-arrow` gem. Added a unit test to verify bulk querying functionality in an integration test. Ensure to set `CHALK_CLIENT_ID`, `CHALK_CLIENT_SECRET`, `CHALK_ENVIRONMENT`, `CHALK_QUERY_SERVER`, and `CHALK_API_SERVER` as environment variables for the tests.



Created with [**Solver**](https://solverai.com)