### PR TITLE
Fix: missing require for grpc client

### DIFF
--- a/lib/chalk_ruby.rb
+++ b/lib/chalk_ruby.rb
@@ -7,6 +7,7 @@ module ChalkRuby
   require 'chalk_ruby/http/response'
   require 'chalk_ruby/http/http_requester_chalk'
   require 'chalk_ruby/client'
+  require 'chalk_ruby/grpc_client'
   require 'chalk_ruby/error'
   require 'chalk_ruby/logger_helper'
 end


### PR DESCRIPTION
Before:
```ruby
[1] development(main)> ChalkRuby::GrpcClient
NameError: uninitialized constant ChalkRuby::GrpcClient
from (pry):1:in `__pry__'
```