### PR TITLE
Make red-arrow an optional dependency

### DIFF
--- a/chalk_ruby.gemspec
+++ b/chalk_ruby.gemspec
@@ -42,11 +42,11 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'multi_json', '~> 1.0'
   spec.add_dependency 'net-http-persistent'
-  spec.add_dependency 'red-arrow', '~> 18.0.0'
 
   spec.add_development_dependency 'httpclient'
   spec.add_development_dependency 'm'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-hooks'
   spec.add_development_dependency 'minitest-proveit'
+  spec.add_development_dependency 'red-arrow', '~> 18.0.0'
 end

--- a/lib/chalk_ruby/grpc_client.rb
+++ b/lib/chalk_ruby/grpc_client.rb
@@ -168,6 +168,9 @@ module ChalkRuby
       correlation_id: nil,
       planner_options: nil
       )
+      unless red_arrow_available?
+        raise NotImplementedError, "query_bulk requires the 'red-arrow' gem. Please add it to your Gemfile: gem 'red-arrow', '~> 18.0.0'"
+      end
       # Convert input to feather format
       inputs_feather = to_feather(input)
 
@@ -412,10 +415,22 @@ module ChalkRuby
 
       private
 
+    def red_arrow_available?
+      @red_arrow_available ||= begin
+        require 'arrow'
+        true
+      rescue LoadError
+        false
+      end
+    end
+
     # Converts Arrow binary data to an array of hashes
     # @param arrow_data [String] Binary Arrow data (IPC stream format)
     # @return [Array<Hash>] Array of hashes with column name as keys and Ruby values
     def arrow_table_to_array(arrow_data)
+      unless red_arrow_available?
+        raise NotImplementedError, "arrow_table_to_array requires the 'red-arrow' gem. Please add it to your Gemfile: gem 'red-arrow', '~> 18.0.0'"
+      end
       require 'arrow'
       
       buffer = Arrow::Buffer.new(arrow_data)
@@ -454,6 +469,9 @@ module ChalkRuby
     end
 
     def to_feather(input_hash)
+      unless red_arrow_available?
+        raise NotImplementedError, "to_feather requires the 'red-arrow' gem. Please add it to your Gemfile: gem 'red-arrow', '~> 18.0.0'"
+      end
       require 'arrow'
 
       # Ensure all values in the input hash are arrays


### PR DESCRIPTION
## Summary
- Made `red-arrow` an optional dependency by moving it from runtime dependencies to development dependencies
- Added conditional loading for Arrow-related functionality with helpful error messages
- Allows the gem to work without red-arrow for basic functionality while still supporting bulk queries when installed

## Changes
- Moved `red-arrow` from `add_dependency` to `add_development_dependency` in gemspec
- Added `red_arrow_available?` helper method to check if the gem is available
- Modified `query_bulk`, `arrow_table_to_array`, and `to_feather` methods to check for red-arrow availability
- When red-arrow is not available, these methods raise `NotImplementedError` with instructions

## Test plan
- [ ] Verify gem installs without red-arrow dependency
- [ ] Test that regular queries work without red-arrow
- [ ] Test that query_bulk raises appropriate error when red-arrow is not installed
- [ ] Test that query_bulk works correctly when red-arrow is installed

🤖 Generated with [Claude Code](https://claude.ai/code)